### PR TITLE
Fix tag.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Salemove/ios-bundle" "1.6.0"
+github "Salemove/ios-bundle" "0.16.0"


### PR DESCRIPTION
FIxed wrong tag to correct one. The current latest SalemoveSDK version is 0.16.0, not 1.6.0.